### PR TITLE
[#111] Relatedness Tab Calls and Displays Data

### DIFF
--- a/DataManager.py
+++ b/DataManager.py
@@ -12,7 +12,7 @@ class DataManager:
     def __init__(self, filename):
         try:
             self.data = []
-            self.df = pd.DataFrame() # DataFrame
+            self.df = None # DataFrame
             self.graph = None # networkx graph
             self.rm = None # Relate Matrix DataFrame
             self.founders = None # Founders DataFrame
@@ -197,7 +197,6 @@ class DataManager:
 
     def getLineages(self):
         if self.lineages == None:
-            pd.set_option('future.no_silent_downcasting', True) # Needed Because DataFrame contains Arrays in some Columns
             self.lineages = Lineages.findLineages(self.df)
         return self.lineages
 

--- a/DataManager.py
+++ b/DataManager.py
@@ -12,7 +12,7 @@ class DataManager:
     def __init__(self, filename):
         try:
             self.data = []
-            self.df = None # DataFrame
+            self.df = pd.DataFrame() # DataFrame
             self.graph = None # networkx graph
             self.rm = None # Relate Matrix DataFrame
             self.founders = None # Founders DataFrame
@@ -197,6 +197,7 @@ class DataManager:
 
     def getLineages(self):
         if self.lineages == None:
+            pd.set_option('future.no_silent_downcasting', True) # Needed Because DataFrame contains Arrays in some Columns
             self.lineages = Lineages.findLineages(self.df)
         return self.lineages
 

--- a/DataManager.py
+++ b/DataManager.py
@@ -138,7 +138,14 @@ class DataManager:
 
     #region ========== Module Access =========
 
-    # TODO: Relate Here
+    #region ========= Relatedness =========
+
+    # TODO: Returns Dataframe for Relatedness Tab
+    # Columns Include: Ego, FgALL, FgCON, Number of Relatives, Inbreeding
+    def getRelatednessStats(self):
+        return self.df
+
+    #endregion
 
     #region ========= Founders =========
 

--- a/GUI.py
+++ b/GUI.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import tkinter as tk
 from tkinter import *
 from tkinter import filedialog, ttk, messagebox
@@ -68,7 +71,7 @@ class GUI:
         self.notebook.insert(0, self.editor_panel, text="Editor")
         self.notebook.insert(1, RelatednessPanel(self.notebook, self), text="Relatedness")
         self.notebook.insert(2, FoundersPanel(self.notebook), text="Founders")
-        self.notebook.insert(3, LineagePanel(self.notebook), text="Lineages")
+        self.notebook.insert(3, LineagePanel(self.notebook, self), text="Lineages")
         self.notebook.insert(4, KinGroupPanel(self.notebook), text="Kin Counter")
         self.notebook.insert(5, KinPanel(self.notebook), text="Kin")
         self.notebook.insert(6, GroupPanel(self.notebook), text="Groups")
@@ -117,7 +120,7 @@ class GUI:
         global data_manager
 
         # Return if DataFrame Already Exists
-        if data_manager.df != None:
+        if not data_manager.df.empty:
             return
         
         # Gain access to Editor Panel
@@ -268,6 +271,7 @@ class EditorPanel(tk.Frame):
         self.maleValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.maleValue.grid(row=1, column=7)
+        self.maleValue.insert(0, "Male") # Default Value
 
         # Female Entry Box
         ttk.Label(self.selection_pane, text = "Female:", 
@@ -276,6 +280,7 @@ class EditorPanel(tk.Frame):
         self.femaleValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.femaleValue.grid(row=2, column=7)
+        self.femaleValue.insert(0, "Female") # Default Value
 
         # Alive Textbox
         ttk.Label(self.selection_pane, text = "Alive:", 
@@ -284,6 +289,7 @@ class EditorPanel(tk.Frame):
         self.aliveValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.aliveValue.grid(row=1, column=9)
+        self.aliveValue.insert(0, "Alive") # Default Value
 
         # Dead Textbox
         ttk.Label(self.selection_pane, text = "Dead:", 
@@ -292,6 +298,7 @@ class EditorPanel(tk.Frame):
         self.deadValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.deadValue.grid(row=2, column=9)
+        self.deadValue.insert(0, "Dead") # Default Value
 
         # Missing Textbox
         ttk.Label(self.selection_pane, text = "Missing:", 
@@ -300,6 +307,7 @@ class EditorPanel(tk.Frame):
         self.missingValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.missingValue.grid(row=1, column=10)
+        self.missingValue.insert(0, "999") # Default Value
 
         # Check Error Button
         checkErrorButton = tk.Button(self.selection_pane, 
@@ -366,11 +374,15 @@ class RelatednessPanel(tk.Frame):
         self.pane.pack(fill=BOTH, expand=True)
 
         # Create Button
-        self.calculate_button = Button(self.pane, text="Caculate Relatedness Stats", command=self.display_relatedness_data)
+        self.calculate_button = Button(self.pane, text="Calculate Relatedness Stats", command=self.display_relatedness_data)
         self.calculate_button.pack(side="bottom")
 
     # Displays Relatedness Data in a Pandastable
     def display_relatedness_data(self):
+        # User Feedback: Alter Cursor because function takes a while
+        self.gui.root.config(cursor="watch")
+        self.gui.root.update()
+
         self.gui.build_data_manager()
         # Delete Button
         self.calculate_button.pack_forget()
@@ -382,6 +394,9 @@ class RelatednessPanel(tk.Frame):
         pt.show()
         
         pt.redrawVisible()
+
+        # Return Cursor to normal
+        self.gui.root.config(cursor="")
 
 class FoundersPanel(tk.Frame):
     def __init__(self, parent):
@@ -395,15 +410,42 @@ class FoundersPanel(tk.Frame):
         label.pack()
 
 class LineagePanel(tk.Frame):
-    def __init__(self, parent):
+    def __init__(self, parent, gui):
         super().__init__(parent)
         self.parent = parent
+        self.gui = gui
 
-        self.temp = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
-        self.temp.pack(side = "bottom")
+        self.create_panel_layout()
+    
+    # Sizes the Frame and adds a button
+    def create_panel_layout(self):
+        self.pane = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
+        self.pane.pack(fill=BOTH, expand=True)
 
-        label = Label(self.temp, text="In Development")
-        label.pack()
+        # Create Button
+        self.calculate_button = Button(self.pane, text="Calculate Lineages", command=self.display_lineage_data)
+        self.calculate_button.pack(side="bottom")
+    
+    # Displays Relatedness Data in a Pandastable
+    def display_lineage_data(self):
+        # User Feedback: Alter Cursor because function takes a while
+        self.gui.root.config(cursor="watch")
+        self.gui.root.update()
+
+        self.gui.build_data_manager()
+        # Delete Button
+        self.calculate_button.pack_forget()
+        # Create Pandastable
+        global data_manager
+        self.pane.pack(fill=BOTH,expand=1)
+        self.table = pt = Table(self.pane, dataframe=data_manager.getLineages(),
+                                showtoolbar=False, showstatusbar=True)
+        pt.show()
+        
+        pt.redrawVisible()
+
+        # Return Cursor to normal
+        self.gui.root.config(cursor="")
 
 class KinGroupPanel(tk.Frame):
     def __init__(self, parent):

--- a/GUI.py
+++ b/GUI.py
@@ -3,7 +3,7 @@ from tkinter import *
 from tkinter import filedialog, ttk, messagebox
 from tkhtmlview import HTMLLabel
 import pandas as pd
-from pandastable import Table, TableModel
+from pandastable import Table, TableModel # Excellent Documentation: https://pandastable.readthedocs.io/en/latest/pandastable.html
 from DataManager import DataManager
 
 data_manager = None
@@ -64,8 +64,9 @@ class GUI:
         "Set up notebook tabs."
         self.ClearTabs()
         self.CreateNotebook()
-        self.notebook.insert(0, EditorPanel(self.notebook), text="Editor")
-        self.notebook.insert(1, RelatednessPanel(self.notebook), text="Relatedness")
+        self.editor_panel = EditorPanel(self.notebook, self)
+        self.notebook.insert(0, self.editor_panel, text="Editor")
+        self.notebook.insert(1, RelatednessPanel(self.notebook, self), text="Relatedness")
         self.notebook.insert(2, FoundersPanel(self.notebook), text="Founders")
         self.notebook.insert(3, LineagePanel(self.notebook), text="Lineages")
         self.notebook.insert(4, KinGroupPanel(self.notebook), text="Kin Counter")
@@ -110,6 +111,33 @@ class GUI:
         else:
             print("Please create a DataFrame first.")
     
+    def build_data_manager(self):
+        global data_manager
+
+        # Return if DataFrame Already Exists
+        if data_manager.df != None:
+            return
+        
+        # Gain access to Editor Panel
+        editor = self.editor_panel
+
+        # Build Parameters for DataManager DataFrame Creation
+        columns = [editor.egoColumnValue.get(),\
+                   editor.fatherColumnValue.get(),\
+                   editor.motherColumnValue.get(),\
+                   editor.sexColumnValue.get(),\
+                   editor.livingColumnValue.get()]
+        values = [editor.maleValue.get(),\
+                  editor.femaleValue.get(),\
+                  editor.aliveValue.get(),\
+                  editor.deadValue.get(),\
+                  editor.missingValue.get()]
+        headerCheckbox = editor.removeHeader.get()
+
+        # Call createPandasDataFrame()        
+        data_manager.createPandasDataFrame(columns, values, headerCheckbox)
+
+        
     # Loads Help Content into Help Tab
     # Runs when Program Boots
     def add_help_content(self):
@@ -141,9 +169,10 @@ class GUI:
         help_label.grid(row=0, column=0, sticky="nsew")
 
 class EditorPanel(tk.Frame):
-    def __init__(self, parent):
+    def __init__(self, parent, gui):
         super().__init__(parent)
         self.parent = parent
+        self.gui = gui
 
         self.firstRow = None
         self.removeHeader = BooleanVar()
@@ -174,7 +203,7 @@ class EditorPanel(tk.Frame):
     def load_data_frame(self, df):
         self.data_pane.pack(fill=BOTH,expand=1)
         self.table = pt = Table(self.data_pane, dataframe=df,
-                                showtoolbar=False, showstatusbar=True, )
+                                showtoolbar=False, showstatusbar=True)
         pt.show()
 
     def load_selection_menu(self, df):
@@ -190,8 +219,8 @@ class EditorPanel(tk.Frame):
         ttk.Label(self.selection_pane, text = "Ego :", 
           font = ("Times New Roman", 10)).grid(row=1, 
           column=0) 
-        n = tk.StringVar() 
-        self.egoDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = n)
+        self.egoColumnValue = tk.StringVar()
+        self.egoDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = self.egoColumnValue)
         self.egoDropdown['values'] = df.columns.tolist()
         self.egoDropdown.grid(row=1, column=1)
 
@@ -199,8 +228,8 @@ class EditorPanel(tk.Frame):
         ttk.Label(self.selection_pane, text = "Father:", 
           font = ("Times New Roman", 10)).grid(row=1, 
           column=2) 
-        n = tk.StringVar() 
-        self.fatherDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = n)
+        self.fatherColumnValue = tk.StringVar()
+        self.fatherDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = self.fatherColumnValue)
         self.fatherDropdown['values'] = df.columns.tolist()
         self.fatherDropdown.grid(row=1, column=3)
 
@@ -208,8 +237,8 @@ class EditorPanel(tk.Frame):
         ttk.Label(self.selection_pane, text = "Mother:", 
           font = ("Times New Roman", 10)).grid(row=2, 
           column=2) 
-        n = tk.StringVar() 
-        self.motherDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = n)
+        self.motherColumnValue = tk.StringVar()
+        self.motherDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = self.motherColumnValue)
         self.motherDropdown['values'] = df.columns.tolist()
         self.motherDropdown.grid(row=2, column=3)
 
@@ -217,8 +246,8 @@ class EditorPanel(tk.Frame):
         ttk.Label(self.selection_pane, text = "Sex:", 
           font = ("Times New Roman", 10)).grid(row=2, 
           column=0) 
-        n = tk.StringVar() 
-        self.sexDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = n)
+        self.sexColumnValue = tk.StringVar()
+        self.sexDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = self.sexColumnValue)
         self.sexDropdown['values'] = df.columns.tolist()
         self.sexDropdown.grid(row=2, column=1)
 
@@ -226,55 +255,50 @@ class EditorPanel(tk.Frame):
         ttk.Label(self.selection_pane, text = "Living:", 
           font = ("Times New Roman", 10)).grid(row=1, 
           column=4) 
-        n = tk.StringVar() 
-        self.livingDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = n)
+        self.livingColumnValue = tk.StringVar()
+        self.livingDropdown = ttk.Combobox(self.selection_pane, width = 10, textvariable = self.livingColumnValue)
         self.livingDropdown['values'] = df.columns.tolist()
         self.livingDropdown.grid(row=1, column=5)
 
-        # Male Textbox
+        # Male Entry Box
         ttk.Label(self.selection_pane, text = "Male:", 
           font = ("Times New Roman", 10)).grid(row=1, 
           column=6) 
-        maleValue = tk.Text(self.selection_pane,
-                        height = 1, 
+        self.maleValue = tk.Entry(self.selection_pane,
                         width = 8)
-        maleValue.grid(row=1, column=7)
+        self.maleValue.grid(row=1, column=7)
 
-        # Female Textbox
+        # Female Entry Box
         ttk.Label(self.selection_pane, text = "Female:", 
           font = ("Times New Roman", 10)).grid(row=2, 
           column=6) 
-        femaleValue = tk.Text(self.selection_pane, 
-                        height = 1, 
+        self.femaleValue = tk.Entry(self.selection_pane,
                         width = 8)
-        femaleValue.grid(row=2, column=7)
+        self.femaleValue.grid(row=2, column=7)
 
         # Alive Textbox
         ttk.Label(self.selection_pane, text = "Alive:", 
           font = ("Times New Roman", 10)).grid(row=1, 
           column=8) 
-        aliveValue = tk.Text(self.selection_pane, 
-                        height = 1, 
+        self.aliveValue = tk.Entry(self.selection_pane,
                         width = 8)
-        aliveValue.grid(row=1, column=9)
+        self.aliveValue.grid(row=1, column=9)
 
         # Dead Textbox
         ttk.Label(self.selection_pane, text = "Dead:", 
           font = ("Times New Roman", 10)).grid(row=2, 
           column=8) 
-        deadValue = tk.Text(self.selection_pane, 
-                        height = 1, 
+        self.deadValue = tk.Entry(self.selection_pane,
                         width = 8)
-        deadValue.grid(row=2, column=9)
+        self.deadValue.grid(row=2, column=9)
 
         # Missing Textbox
         ttk.Label(self.selection_pane, text = "Missing:", 
           font = ("Times New Roman", 10)).grid(row=2, 
           column=10) 
-        deadValue = tk.Text(self.selection_pane, 
-                        height = 1, 
+        self.missingValue = tk.Entry(self.selection_pane,
                         width = 8)
-        deadValue.grid(row=1, column=10)
+        self.missingValue.grid(row=1, column=10)
 
         # Check Error Button
         checkErrorButton = tk.Button(self.selection_pane, 
@@ -328,15 +352,33 @@ class EditorPanel(tk.Frame):
         self.livingDropdown['values'] = self.table.model.df.columns.tolist()
 
 class RelatednessPanel(tk.Frame):
-    def __init__(self, parent):
+    def __init__(self, parent, gui):
         super().__init__(parent)
         self.parent = parent
+        self.gui = gui
 
-        self.temp = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
-        self.temp.pack()
+        self.create_panel_layout()
+    
+    def create_panel_layout(self):
+        self.pane = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
+        self.pane.pack(fill=BOTH, expand=True)
 
-        label = Label(self.temp, text="In Development")
-        label.pack()
+        # Create Button
+        self.calculate_button = Button(self.pane, text="Caculate Relatedness Stats", command=self.display_relatedness_data)
+        self.calculate_button.pack(side="bottom")
+
+    def display_relatedness_data(self):
+        self.gui.build_data_manager()
+        # Delete Button
+        self.calculate_button.pack_forget()
+        # Create Pandastable
+        global data_manager
+        self.pane.pack(fill=BOTH,expand=1)
+        self.table = pt = Table(self.pane, dataframe=data_manager.getRelatednessStats(),
+                                showtoolbar=False, showstatusbar=True)
+        pt.show()
+        
+        pt.redrawVisible()
 
 class FoundersPanel(tk.Frame):
     def __init__(self, parent):

--- a/GUI.py
+++ b/GUI.py
@@ -1,6 +1,3 @@
-import warnings
-warnings.simplefilter(action='ignore', category=FutureWarning)
-
 import tkinter as tk
 from tkinter import *
 from tkinter import filedialog, ttk, messagebox
@@ -71,7 +68,7 @@ class GUI:
         self.notebook.insert(0, self.editor_panel, text="Editor")
         self.notebook.insert(1, RelatednessPanel(self.notebook, self), text="Relatedness")
         self.notebook.insert(2, FoundersPanel(self.notebook), text="Founders")
-        self.notebook.insert(3, LineagePanel(self.notebook, self), text="Lineages")
+        self.notebook.insert(3, LineagePanel(self.notebook), text="Lineages")
         self.notebook.insert(4, KinGroupPanel(self.notebook), text="Kin Counter")
         self.notebook.insert(5, KinPanel(self.notebook), text="Kin")
         self.notebook.insert(6, GroupPanel(self.notebook), text="Groups")
@@ -120,7 +117,7 @@ class GUI:
         global data_manager
 
         # Return if DataFrame Already Exists
-        if not data_manager.df.empty:
+        if data_manager.df != None:
             return
         
         # Gain access to Editor Panel
@@ -271,7 +268,6 @@ class EditorPanel(tk.Frame):
         self.maleValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.maleValue.grid(row=1, column=7)
-        self.maleValue.insert(0, "Male") # Default Value
 
         # Female Entry Box
         ttk.Label(self.selection_pane, text = "Female:", 
@@ -280,7 +276,6 @@ class EditorPanel(tk.Frame):
         self.femaleValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.femaleValue.grid(row=2, column=7)
-        self.femaleValue.insert(0, "Female") # Default Value
 
         # Alive Textbox
         ttk.Label(self.selection_pane, text = "Alive:", 
@@ -289,7 +284,6 @@ class EditorPanel(tk.Frame):
         self.aliveValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.aliveValue.grid(row=1, column=9)
-        self.aliveValue.insert(0, "Alive") # Default Value
 
         # Dead Textbox
         ttk.Label(self.selection_pane, text = "Dead:", 
@@ -298,7 +292,6 @@ class EditorPanel(tk.Frame):
         self.deadValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.deadValue.grid(row=2, column=9)
-        self.deadValue.insert(0, "Dead") # Default Value
 
         # Missing Textbox
         ttk.Label(self.selection_pane, text = "Missing:", 
@@ -307,7 +300,6 @@ class EditorPanel(tk.Frame):
         self.missingValue = tk.Entry(self.selection_pane,
                         width = 8)
         self.missingValue.grid(row=1, column=10)
-        self.missingValue.insert(0, "999") # Default Value
 
         # Check Error Button
         checkErrorButton = tk.Button(self.selection_pane, 
@@ -374,15 +366,11 @@ class RelatednessPanel(tk.Frame):
         self.pane.pack(fill=BOTH, expand=True)
 
         # Create Button
-        self.calculate_button = Button(self.pane, text="Calculate Relatedness Stats", command=self.display_relatedness_data)
+        self.calculate_button = Button(self.pane, text="Caculate Relatedness Stats", command=self.display_relatedness_data)
         self.calculate_button.pack(side="bottom")
 
     # Displays Relatedness Data in a Pandastable
     def display_relatedness_data(self):
-        # User Feedback: Alter Cursor because function takes a while
-        self.gui.root.config(cursor="watch")
-        self.gui.root.update()
-
         self.gui.build_data_manager()
         # Delete Button
         self.calculate_button.pack_forget()
@@ -394,9 +382,6 @@ class RelatednessPanel(tk.Frame):
         pt.show()
         
         pt.redrawVisible()
-
-        # Return Cursor to normal
-        self.gui.root.config(cursor="")
 
 class FoundersPanel(tk.Frame):
     def __init__(self, parent):
@@ -410,42 +395,15 @@ class FoundersPanel(tk.Frame):
         label.pack()
 
 class LineagePanel(tk.Frame):
-    def __init__(self, parent, gui):
+    def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
-        self.gui = gui
 
-        self.create_panel_layout()
-    
-    # Sizes the Frame and adds a button
-    def create_panel_layout(self):
-        self.pane = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
-        self.pane.pack(fill=BOTH, expand=True)
+        self.temp = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
+        self.temp.pack(side = "bottom")
 
-        # Create Button
-        self.calculate_button = Button(self.pane, text="Calculate Lineages", command=self.display_lineage_data)
-        self.calculate_button.pack(side="bottom")
-    
-    # Displays Relatedness Data in a Pandastable
-    def display_lineage_data(self):
-        # User Feedback: Alter Cursor because function takes a while
-        self.gui.root.config(cursor="watch")
-        self.gui.root.update()
-
-        self.gui.build_data_manager()
-        # Delete Button
-        self.calculate_button.pack_forget()
-        # Create Pandastable
-        global data_manager
-        self.pane.pack(fill=BOTH,expand=1)
-        self.table = pt = Table(self.pane, dataframe=data_manager.getLineages(),
-                                showtoolbar=False, showstatusbar=True)
-        pt.show()
-        
-        pt.redrawVisible()
-
-        # Return Cursor to normal
-        self.gui.root.config(cursor="")
+        label = Label(self.temp, text="In Development")
+        label.pack()
 
 class KinGroupPanel(tk.Frame):
     def __init__(self, parent):

--- a/GUI.py
+++ b/GUI.py
@@ -111,6 +111,8 @@ class GUI:
         else:
             print("Please create a DataFrame first.")
     
+    # Called before any Calculation in all Tabs except Editor
+    # Builds the backend DataFrame based on User Input
     def build_data_manager(self):
         global data_manager
 
@@ -136,7 +138,6 @@ class GUI:
 
         # Call createPandasDataFrame()        
         data_manager.createPandasDataFrame(columns, values, headerCheckbox)
-
         
     # Loads Help Content into Help Tab
     # Runs when Program Boots
@@ -359,6 +360,7 @@ class RelatednessPanel(tk.Frame):
 
         self.create_panel_layout()
     
+    # Sizes the Frame and adds a button
     def create_panel_layout(self):
         self.pane = tk.Frame(self, highlightbackground='Black', highlightthickness=2)
         self.pane.pack(fill=BOTH, expand=True)
@@ -367,6 +369,7 @@ class RelatednessPanel(tk.Frame):
         self.calculate_button = Button(self.pane, text="Caculate Relatedness Stats", command=self.display_relatedness_data)
         self.calculate_button.pack(side="bottom")
 
+    # Displays Relatedness Data in a Pandastable
     def display_relatedness_data(self):
         self.gui.build_data_manager()
         # Delete Button


### PR DESCRIPTION
Relatedness Tab now has a button that further develops the datamanager if needed by grabbing user entries from the Editor Tab.

The button also displays the relatedness tab results by calling it from the datamanager.

The button gets deleted after pressing to display more data. This should be easy to change if wanted.